### PR TITLE
Enhanced installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Simple (and unofficial) wrapper to handle the public API of [Unsplash](http://un
 ## Installation
 
 ```bash
-$ git clone https://github.com/cgrs/node-unsplash.git
-$ cd node-unsplash
-$ npm install
+$ npm install cgrs/node-unsplash
 ```
 ## Usage
 ```javascript

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "author": "carlos gonzález <cgrs@cgrs.tk> (http://cgrs.tk)",
   "license": "MIT",
   "dependencies": {
-    "request": "^2.64.0"
+    "request": "^2.64.0",
+    "babel": "^5.8.23"
   },
   "devDependencies": {
-    "babel": "^5.8.23",
     "mocha": "^2.3.3",
     "should": "^7.1.0"
   },


### PR DESCRIPTION
Although it needs `babel` to be installed, now you can just run `npm install cgrs/node-unsplash` and give it a go, ready to use :wink: 
